### PR TITLE
Integrate pytest with tested on CI win-wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,52 +182,9 @@ jobs:
               ${{github.workspace}}\\ccache.exe -sv # Print current cache stats
 
 
-            CIBW_TEST_COMMAND_LINUX: |
-              # The wheels are installed automatically and available.
-
-              # Fetch models from translateLocally repository.
-              python -m bergamot download -m en-de-tiny
-              python -m bergamot download -m de-en-tiny
-              python -m bergamot ls
-
-              # Fetch models from opus repository.
-              python -m bergamot download -m eng-fin-tiny -r opus
-              python -m bergamot ls -r opus
-
-              # Run the sample python script shipped with module
-              python -m bergamot translate --model en-de-tiny <<< "Hello World"
-              python -m bergamot translate --model en-de-tiny de-en-tiny <<< "Hello World"
-              python -m bergamot translate --model eng-fin-tiny --repository opus <<< "Hello World"
-
-            CIBW_TEST_COMMAND_MACOS: |
-              # The wheels are installed automatically and available.
-
-              # Fetch models from translateLocally repository.
-              python -m bergamot download -m en-de-tiny
-              python -m bergamot download -m de-en-tiny
-              python -m bergamot ls
-
-              # Fetch models from opus repository.
-              python -m bergamot download -m eng-fin-tiny -r opus
-              python -m bergamot ls -r opus
-
-              # Run the sample python script shipped with module
-              python -m bergamot translate --model en-de-tiny <<< "Hello World"
-              python -m bergamot translate --model en-de-tiny de-en-tiny <<< "Hello World"
-              python -m bergamot translate --model eng-fin-tiny --repository opus <<< "Hello World"
-
-            CIBW_TEST_COMMAND_WINDOWS: |
-              python -m bergamot download -m en-de-tiny
-              python -m bergamot download -m de-en-tiny
-              python -m bergamot ls
-
-              python -m bergamot download -m eng-fin-tiny -r opus
-              python -m bergamot ls -r opus
-
-              python -m bergamot translate --model en-de-tiny <<< "Hello World"
-              python -m bergamot translate --model en-de-tiny de-en-tiny <<< "Hello World"
-              python -m bergamot translate --model eng-fin-tiny --repository opus <<< "Hello World"
-
+            CIBW_TEST_EXTRAS: test
+            CIBW_TEST_COMMAND: |
+              python -m pytest --pyargs bergamot -s
 
 
         - uses: actions/upload-artifact@v2

--- a/bindings/python/tests/test_all.py
+++ b/bindings/python/tests/test_all.py
@@ -1,0 +1,25 @@
+# type: ignore
+import pytest
+from bergamot import REPOSITORY, ResponseOptions, Service, ServiceConfig, VectorString
+from bergamot.utils import toJSON
+
+
+def test_basic():
+    keys = ["browsermt"]
+    models = ["de-en-tiny"]
+    config = ServiceConfig(numWorkers=1, logLevel="critical")
+    service = Service(config)
+    for repository in keys:
+        # models = REPOSITORY.models(repository, filter_downloaded=False)
+        for model in models:
+            REPOSITORY.download(repository, model)
+
+        for modelId in models:
+            configPath = REPOSITORY.modelConfigPath(repository, modelId)
+            model = service.modelFromConfigPath(configPath)
+            options = ResponseOptions(alignment=True, qualityScores=True, HTML=False)
+            print(repository, modelId)
+            source = "1 2 3 4 5 6 7 8 9"
+            responses = service.translate(model, VectorString([source]), options)
+            for response in responses:
+                print(toJSON(response, indent=4))

--- a/bindings/python/tests/test_cmdline.py
+++ b/bindings/python/tests/test_cmdline.py
@@ -1,0 +1,45 @@
+import subprocess as sp
+import sys
+from subprocess import PIPE, STDOUT, Popen
+
+
+def run_successfully(cmd, stdin=None):
+    print(" ".join(cmd))
+    if stdin is not None:
+        p = Popen(cmd, stdout=PIPE, stdin=PIPE, stderr=PIPE)
+        stdin = stdin.encode()
+        stdout_data = p.communicate(input=stdin)[0]
+        p.stdin.close()
+        p.wait()
+        return stdout_data
+    else:
+        p = sp.run(cmd, capture_output=True)
+        p.check_returncode()
+        return p.stdout
+
+
+def test_cmdline():
+    python = sys.executable
+    base = [python, "-m", "bergamot"]
+
+    for model in ["en-de-tiny", "de-en-tiny"]:
+        run_successfully(base + ["download", "-m", model])
+
+    run_successfully(base + ["ls"])
+
+    opus_args = ["-r", "opus"]
+    run_successfully(base + ["download", "-m", "eng-fin-tiny"] + opus_args)
+    run_successfully(base + ["ls"] + opus_args)
+    # Run the sample python script shipped with module
+
+    for model in ["en-de-tiny", "de-en-tiny"]:
+        data = run_successfully(
+            base + ["translate", "--model", model], stdin="Hello World"
+        )
+        print(data)
+
+    data = run_successfully(
+        base + ["translate", "--model", "eng-fin-tiny"] + opus_args,
+        stdin="Hello World",
+    )
+    print(data)

--- a/bindings/python/tests/test_html.py
+++ b/bindings/python/tests/test_html.py
@@ -1,0 +1,128 @@
+# type: ignore
+from collections import Counter
+from string import whitespace
+
+import pytest
+from bergamot import REPOSITORY, ResponseOptions, Service, ServiceConfig, VectorString
+
+
+@pytest.mark.skip(reason="Not required to run now.")
+def test_html():
+    from lxml import etree, html
+
+    MODEL = "en-de-tiny"
+    config = ServiceConfig(numWorkers=4, logLevel="warn")
+    service = Service(config)
+    config_path = REPOSITORY.modelConfigPath("browsermt", MODEL)
+    model = service.modelFromConfigPath(config_path)
+
+    example = """
+<div class="wrap">
+    <div class="image-wrap"><img src="/images/about.jpg" alt=""></div>
+    <h2 id="the-bergamot-project">Das Projekt Bergamot</h2>
+    <p>Das Bergamot-Projekt wird die Übersetzung der Client-Seite der Maschine in einem Webbrowser ergänzen und verbessern.</p>
+    <p>Im Gegensatz zu aktuellen <b>Cloud-basierten Optionen</b>, die di<s>rekt</s> auf den Rechnern der Nutzer laufen, die Bürgerinnen und Bürger, ihre Privatsphäre zu bewahren und erhöht die Verbreitung von Sprachtechnologien in Europa in verschiedenen Sektoren, die Vertraulichkeit erfordern. Freie Software, die mit einem Open-Source-Webbrowser wie Mozilla Firefox integriert ist, wird die Akzeptanz von unten nach oben durch Nicht-Experten ermöglichen, was zu Kosteneinsparungen für private und öffentliche Nutzer führt, die andernfalls Übersetzungen beschaffen oder einsprachig arbeiten würden.</p>
+    <p>Bergamot ist ein Konsortium, das von der Universität Edinburgh mit den Partnern Charles University in Prag, der University of Sheffield, der University of Tartu und Mozilla koordiniert wird.</p>
+</div>
+"""
+
+    def translate(src, HTML=True):
+        options = ResponseOptions(HTML=HTML)
+        responses = service.translate(model, VectorString([src]), options)
+        return responses[0].target.text
+
+    def get_surrounding_text(element):
+        """
+        Places for spaces: 0 <b> 1 … 2 </b> 3
+        0 before_open: prev.tail[-1] if prev else parent.text[-1]
+        1 after_open: elem.text[0]
+        2 before_close: last_child.tail[-1] if last_child else elem.text[-1]
+        3 after_close: elem.tail[0]
+        """
+        before_open = (
+            element.getprevious().tail
+            if element.getprevious() is not None
+            else element.getparent().text
+        )
+        after_open = element.text
+        last_child = next(element.iterchildren(reversed=True), None)
+        before_close = last_child.tail if last_child is not None else element.text
+        after_close = element.tail
+        return [before_open, after_open, before_close, after_close]
+
+    def has_surrounding_text(element):
+        return [
+            text is not None and text.strip() != ""
+            for text in get_surrounding_text(element)
+        ]
+
+    def has_surrounding_spaces(element):
+        return [
+            isinstance(text, str) and len(text) > 0 and text[index] in whitespace
+            for text, index in zip(get_surrounding_text(element), [-1, 0, -1, 0])
+        ]
+
+    def format_whitespace(slots):
+        return "{}<t>{}…{}</t>{}".format(*["␣" if slot else "⊘" for slot in slots])
+
+    def format_element(element):
+        return "<{}{}>".format(
+            element.tag,
+            "".join(
+                f' {key}="{val}"' for key, val in element.items() if key != "x-test-id"
+            ),
+        )
+
+    def clean_html(src):
+        tree = html.fromstring(src)
+        return html.tostring(tree, encoding="utf-8").decode()
+
+    def compare_html(src, translate):
+        """Marks tags, then translates and compares translated HTML"""
+        src_tree = html.fromstring(src)
+        src_elements = {str(n): element for n, element in enumerate(src_tree.iter(), 1)}
+        # Assign each element a unique id to help it correlate after translation
+        for n, element in src_elements.items():
+            element.set("x-test-id", n)
+        src = html.tostring(src_tree, encoding="utf-8").decode()
+
+        tgt = translate(src)
+        tgt_tree = html.fromstring(tgt)
+
+        # Test if all elements are referenced once
+        print("Elements referenced:")
+        tgt_element_count = Counter(
+            element.get("x-test-id") for element in tgt_tree.iter()
+        )
+        for n, element in src_elements.items():
+            count = tgt_element_count[n]
+            if count != 1:
+                print(f"{count}: {element!r}")
+
+        # Test whether all elements have text around them (i.e. no empty elements
+        # that should not be empty)
+        print("Elements with missing text:")
+        for tgt_element in tgt_tree.iter():
+            n = tgt_element.get("x-test-id")
+            src_element = src_elements[n]
+            tgt_text = has_surrounding_text(tgt_element)
+            src_text = has_surrounding_text(src_element)
+            if tgt_text != src_text:
+                print(f"{element!r}: {tgt_text!r} (input: {src_text!r})")
+
+        # Test whether the spaces around the elements are present. All spaces are
+        # treated as a single space (unless <pre></pre>) thus it doesn't need to
+        # be exactly the same. But space vs no space does affect the flow of the
+        # document.
+        print("Elements with differences in whitespace around tags")
+        for tgt_element in tgt_tree.iter():
+            n = tgt_element.get("x-test-id")
+            src_element = src_elements[n]
+            tgt_spaces = has_surrounding_spaces(tgt_element)
+            src_spaces = has_surrounding_spaces(src_element)
+            if tgt_spaces != src_spaces:
+                print(
+                    f"{format_whitespace(tgt_spaces)} (input: {format_whitespace(src_spaces)}) for {format_element(tgt_element)}"
+                )
+
+    compare_html(example, translate)

--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,7 @@ setup(
     extras_require={"test": ["pytest>=6.0"]},
     license_files=("LICENSE",),
     python_requires=">=3.6",
-    packages=["bergamot"],
+    packages=["bergamot", "bergamot.tests"],
     package_dir={"bergamot": "bindings/python"},
     install_requires=["requests", "pyyaml>=5.1", "appdirs"],
     entry_points={


### PR DESCRIPTION
This is intended to replace the hairy shell-script based `bergamot-translator-tests` at least for this fork in the long-term. This is not perhaps the best suited for speed, multithreaded use-cases. However for most high-level stuff like checking basic input output, property testing, parsing and validating generated HTML, the comfort of using Python in place of bash horror should be a boost in productivity.